### PR TITLE
cloning from `znode` branch

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     apt-get install -y software-properties-common && \
     add-apt-repository ppa:bitcoin/bitcoin -y && \
     apt-get update && \
-    apt-get install -y git build-essential libtool autotools-dev automake pkg-config bsdmainutils libdb4.8-dev libdb4.8++-dev libssl-dev libevent-dev libboost-all-dev libminiupnpc-dev libevent-pthreads-2.0-5 && \
-    git clone --depth 1 -b master https://github.com/zcoinofficial/zcoin /zcoin && \
+    apt-get install -y git build-essential libtool autotools-dev automake pkg-config bsdmainutils libdb4.8-dev libdb4.8++-dev libssl-dev libevent-dev libboost-all-dev libminiupnpc-dev libevent-pthreads-2.0-5 libzmq3-dev && \
+    git clone --depth 1 -b znode https://github.com/zcoinofficial/zcoin /zcoin && \
     cd /zcoin && /zcoin/autogen.sh && ./configure && make
+


### PR DESCRIPTION
`znode` has up-to-date code for Znode. This branch will be update accordingly until the official release.